### PR TITLE
Add manual save and optional audio upload

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,10 +146,7 @@ if (genSentenceBtn) {
                 console.warn('TTS generation failed', ttsErr);
             }
 
-            // Auto-save (even if audio failed)
-            autoSaveCard(sentence, chinese, audioUrl);
-
-            genSentenceStatus.textContent = audioUrl ? 'Card generated & saved!' : 'Card saved (no audio)';
+            genSentenceStatus.textContent = audioUrl ? 'Sentence & audio ready. Click Save.' : 'Sentence ready. Click Save.';
         } catch (err) {
             console.error(err);
             genSentenceStatus.textContent = 'Error generating. Check API key / quota.';
@@ -549,17 +546,13 @@ form.addEventListener('submit', (e) => {
 
     const file = audioInput ? audioInput.files[0] : null;
 
-    // If AI generated voice exists, use it regardless of file selection
-    if (generatedAudioData) {
-        handleData(generatedAudioData);
-        generatedAudioData = null; // reset for next card
-        return;
-    }
-
     if (file) {
         const reader = new FileReader();
         reader.onload = (ev) => handleData(ev.target.result);
         reader.readAsDataURL(file);
+    } else if (generatedAudioData) {
+        handleData(generatedAudioData);
+        generatedAudioData = null; // reset for next card
     } else {
         // if no new file picked and editing, keep previous audioData
         if (editingCardId) {

--- a/index.html
+++ b/index.html
@@ -45,7 +45,14 @@
                     <textarea id="answer" required></textarea>
                 </label>
 
-                <button type="submit" id="save-card-btn" class="primary-btn hidden">Save Card</button>
+                <div class="inline-audio-tools">
+                    <label>
+                        Optional audio file
+                        <input type="file" id="audio" accept="audio/*" />
+                    </label>
+                </div>
+
+                <button type="submit" id="save-card-btn" class="primary-btn">Save Card</button>
                 <button type="button" id="cancel-edit-btn" class="hidden">Cancel</button>
                 <small id="save-status" class="hidden"></small>
             </form>


### PR DESCRIPTION
## Summary
- decouple sentence generation from saving cards
- prefer user-uploaded audio or generated audio when saving
- restore audio upload input and always show Save button

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_685203885d6883209e74a7f9aae48c95