### PR TITLE
Add playback speed toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 web app for dad - space repetition for learning English.
 
 This is made mostly by Codex! o3
+New feature: playback speed toggle button to switch between normal and slow (80%) playback.

--- a/app.js
+++ b/app.js
@@ -483,6 +483,7 @@ const cardAudio = document.getElementById('card-audio');
 const audioToggleBtn = document.getElementById('audio-toggle-btn');
 const rewindBtn = document.getElementById('rewind-5-btn');
 const restartBtn = document.getElementById('restart-btn');
+const speedToggleBtn = document.getElementById('speed-toggle-btn');
 const showAnswerBtn = document.getElementById('show-answer');
 const cardList = document.getElementById('card-list');
 const saveCardBtn = document.getElementById('save-card-btn');
@@ -529,6 +530,7 @@ function setupAudioLooping() {
 const ratingButtons = document.querySelectorAll('.rating-buttons button');
 
 let audioLoopTimeout = null;
+let slowPlayback = false; // global playback speed state
 
 let editingCardId = null; // if not null, we're editing existing card
 
@@ -848,6 +850,8 @@ function showNextCard() {
         cardAudio.src = currentCard.audioData;
         cardAudio.load();
 
+        cardAudio.playbackRate = slowPlayback ? 0.8 : 1;
+
         setupAudioLooping();
         cardAudio.play().catch(() => {/* autoplay might be blocked */});
         if (audioToggleBtn) {
@@ -860,6 +864,10 @@ function showNextCard() {
         if (restartBtn) {
             restartBtn.classList.remove('hidden');
         }
+        if (speedToggleBtn) {
+            speedToggleBtn.classList.remove('hidden');
+            speedToggleBtn.textContent = slowPlayback ? '0.8x' : '1x';
+        }
     } else {
         cardAudio.removeAttribute('src');
         cardAudio.load();
@@ -871,6 +879,9 @@ function showNextCard() {
         }
         if (restartBtn) {
             restartBtn.classList.add('hidden');
+        }
+        if (speedToggleBtn) {
+            speedToggleBtn.classList.add('hidden');
         }
     }
 
@@ -923,6 +934,15 @@ if (restartBtn) {
         if (!cardAudio.paused) {
             cardAudio.play().catch(() => {});
         }
+    });
+}
+
+// Playback speed toggle (1x / 0.8x)
+if (speedToggleBtn) {
+    speedToggleBtn.addEventListener('click', () => {
+        slowPlayback = !slowPlayback;
+        cardAudio.playbackRate = slowPlayback ? 0.8 : 1;
+        speedToggleBtn.textContent = slowPlayback ? '0.8x' : '1x';
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                         <button id="restart-btn" class="secondary-btn hidden" title="Restart">⏮️</button>
                         <button id="rewind-5-btn" class="secondary-btn hidden">⏪ 5s</button>
                         <button id="audio-toggle-btn" class="secondary-btn hidden" title="Play/Pause">▶️</button>
+                        <button id="speed-toggle-btn" class="secondary-btn hidden" title="Playback Speed">1x</button>
                     </div>
                     <button id="show-answer" class="primary-btn">Show Answer</button>
                     <div id="reveal-area" class="hidden">


### PR DESCRIPTION
## Summary
- add new `speed-toggle-btn` button in the study view
- allow toggling audio playback between normal speed and 80% speed
- document speed toggle in README

## Testing
- `node -c app.js`
- `node -e "console.log('node works')"`


------
https://chatgpt.com/codex/tasks/task_e_6854bde6fccc8320a236712b5b287929