### PR TITLE
feat: enable sortable study list

### DIFF
--- a/style.css
+++ b/style.css
@@ -177,6 +177,10 @@ textarea {
     color: #333;
 }
 
+#review-list li.dragging {
+    opacity: 0.5;
+}
+
 #review-card-box {
     background: white;
     padding: 1rem;


### PR DESCRIPTION
## Summary
- add persistent manual ordering for flashcards
- allow dragging in study list while keeping pinned cards on top
- style dragging state for clarity

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68940caf048883209222314a46ccea34